### PR TITLE
Refactor server codes for a better readability

### DIFF
--- a/server/echo.go
+++ b/server/echo.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+func newEcho() *echo.Echo {
+	e := echo.New()
+	e.HideBanner = true
+	e.HidePort = true
+
+	e.HEAD("/", func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
+
+	e.GET("/", func(c echo.Context) error {
+		return c.JSON(http.StatusOK, map[string]string{
+			"service":   "apigateway",
+			"version":   "v1",
+			"host":      c.Request().Host,
+			"timestamp": time.Now().UTC().String(),
+		})
+	})
+
+	return e
+}

--- a/server/grpc_gateway.go
+++ b/server/grpc_gateway.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	googlemetadata "cloud.google.com/go/compute/metadata"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/sirupsen/logrus"
+	"github.com/taehoio/apigateway/config"
+	baemincryptov1 "github.com/taehoio/idl/gen/go/services/baemincrypto/v1"
+	"go.opencensus.io/plugin/ocgrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func getIDTokenInGCP(serviceURL string) (string, error) {
+	tokenURL := fmt.Sprintf("/instance/service-accounts/default/identity?audience=%s", serviceURL)
+	return googlemetadata.Get(tokenURL)
+}
+
+func withMarshalerOption() runtime.ServeMuxOption {
+	return runtime.WithMarshalerOption(
+		runtime.MIMEWildcard,
+		&runtime.JSONPb{
+			MarshalOptions: protojson.MarshalOptions{
+				UseProtoNames:   true,
+				EmitUnpopulated: true,
+			},
+			UnmarshalOptions: protojson.UnmarshalOptions{
+				DiscardUnknown: true,
+			},
+		},
+	)
+}
+
+func withMetadata(cfg config.Config) runtime.ServeMuxOption {
+	return runtime.WithMetadata(func(ctx context.Context, req *http.Request) metadata.MD {
+		md := metadata.MD{}
+
+		if cfg.IsInGCP() {
+			idToken, err := getIDTokenInGCP(strings.Join([]string{
+				cfg.BaemincryptoGRPCServiceURL(),
+			}, ","))
+			if err != nil {
+				logrus.StandardLogger().Error(err)
+			}
+			md.Append("Authorization", "Bearer "+idToken)
+		} else {
+			idToken := cfg.IDToken()
+			md.Append("Authorization", "Bearer "+idToken)
+		}
+
+		return md
+	})
+}
+
+func withSecureOption(cfg config.Config) (grpc.DialOption, error) {
+	secureOpt := grpc.WithInsecure()
+
+	if cfg.ShouldUseGRPCClientTLS() {
+		creds, err := credentials.NewClientTLSFromFile(cfg.CACertFile(), "")
+		if err != nil {
+			return nil, err
+		}
+
+		secureOpt = grpc.WithTransportCredentials(creds)
+	}
+
+	return secureOpt, nil
+}
+
+func withTracingStatsHandler() grpc.DialOption {
+	return grpc.WithStatsHandler(&ocgrpc.ClientHandler{})
+}
+
+func registerBaemincryptoService(ctx context.Context, gwMux *runtime.ServeMux, endpoint string, opts ...grpc.DialOption) error {
+	baemincryptov1Conn, err := grpc.Dial(
+		endpoint,
+		opts...,
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := baemincryptov1.RegisterBaemincryptoServiceHandler(
+		ctx,
+		gwMux,
+		baemincryptov1Conn,
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func newGRPCGatewayMux(ctx context.Context, cfg config.Config) (*runtime.ServeMux, error) {
+	gwMux := runtime.NewServeMux(
+		withMarshalerOption(),
+		withMetadata(cfg),
+	)
+
+	secureOpt, err := withSecureOption(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := registerBaemincryptoService(
+		ctx,
+		gwMux,
+		cfg.BaemincryptoGRPCServiceEndpoint(),
+		secureOpt,
+		withTracingStatsHandler(),
+	); err != nil {
+		return nil, err
+	}
+
+	return gwMux, nil
+}

--- a/server/http_server.go
+++ b/server/http_server.go
@@ -4,132 +4,45 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
-	"time"
 
-	googlemetadata "cloud.google.com/go/compute/metadata"
 	"contrib.go.opencensus.io/exporter/stackdriver/propagation"
 	"github.com/gorilla/mux"
-	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	"github.com/labstack/echo/v4"
-	"github.com/sirupsen/logrus"
 	"github.com/taehoio/apigateway/config"
-	baemincryptov1 "github.com/taehoio/idl/gen/go/services/baemincrypto/v1"
-	"go.opencensus.io/plugin/ocgrpc"
 	"go.opencensus.io/plugin/ochttp"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/metadata"
-	"google.golang.org/protobuf/encoding/protojson"
 )
 
-func newEcho() *echo.Echo {
-	e := echo.New()
-	e.HideBanner = true
-	e.HidePort = true
+func newRouter(ctx context.Context, cfg config.Config) (*mux.Router, error) {
+	rtr := mux.NewRouter()
 
-	e.HEAD("/", func(c echo.Context) error {
-		return c.NoContent(http.StatusOK)
-	})
+	ec := newEcho()
+	rtr.HandleFunc("/", ec.ServeHTTP)
 
-	e.GET("/", func(c echo.Context) error {
-		return c.JSON(http.StatusOK, map[string]string{
-			"service":   "apigateway",
-			"version":   "v1",
-			"host":      c.Request().Host,
-			"timestamp": time.Now().UTC().String(),
-		})
-	})
-
-	return e
-}
-
-func getIDTokenInGCP(serviceURL string) (string, error) {
-	tokenURL := fmt.Sprintf("/instance/service-accounts/default/identity?audience=%s", serviceURL)
-	return googlemetadata.Get(tokenURL)
-}
-
-func newGRPCGateway(ctx context.Context, cfg config.Config) (*runtime.ServeMux, error) {
-	gwMux := runtime.NewServeMux(
-		runtime.WithMarshalerOption(
-			runtime.MIMEWildcard,
-			&runtime.JSONPb{
-				MarshalOptions: protojson.MarshalOptions{
-					UseProtoNames:   true,
-					EmitUnpopulated: true,
-				},
-				UnmarshalOptions: protojson.UnmarshalOptions{
-					DiscardUnknown: true,
-				},
-			},
-		),
-		runtime.WithMetadata(func(ctx context.Context, req *http.Request) metadata.MD {
-			md := metadata.MD{}
-
-			if cfg.IsInGCP() {
-				idToken, err := getIDTokenInGCP(strings.Join([]string{
-					cfg.BaemincryptoGRPCServiceURL(),
-				}, ","))
-				if err != nil {
-					logrus.StandardLogger().Error(err)
-				}
-				md.Append("Authorization", "Bearer "+idToken)
-			} else {
-				idToken := cfg.IDToken()
-				md.Append("Authorization", "Bearer "+idToken)
-			}
-
-			return md
-		}),
-	)
-
-	secureOpt := grpc.WithInsecure()
-	if cfg.ShouldUseGRPCClientTLS() {
-		creds, err := credentials.NewClientTLSFromFile(cfg.CACertFile(), "")
-		if err != nil {
-			return nil, err
-		}
-		secureOpt = grpc.WithTransportCredentials(creds)
-	}
-
-	baemincryptov1Conn, err := grpc.Dial(
-		cfg.BaemincryptoGRPCServiceEndpoint(),
-		secureOpt,
-		grpc.WithStatsHandler(&ocgrpc.ClientHandler{}),
-	)
+	gwMux, err := newGRPCGatewayMux(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
-	if err := baemincryptov1.RegisterBaemincryptoServiceHandler(
-		ctx,
-		gwMux,
-		baemincryptov1Conn,
-	); err != nil {
-		return nil, err
-	}
+	rtr.Handle("/{serviceName}/{version}/{rest:.*}", gwMux)
 
-	return gwMux, nil
+	return rtr, nil
 }
 
-func NewHTTPServer(ctx context.Context, cfg config.Config) (*http.Server, error) {
-	r := mux.NewRouter()
-
-	e := newEcho()
-	r.HandleFunc("/", e.ServeHTTP)
-
-	gwMux, err := newGRPCGateway(ctx, cfg)
-	if err != nil {
-		return nil, err
-	}
-	r.Handle("/{serviceName}/{version}/{rest:.*}", gwMux)
-
-	httpMux := http.NewServeMux()
-	httpMux.Handle("/", r)
-
-	httpHandler := &ochttp.Handler{
+func handlerWithTracingPropagation(httpMux *http.ServeMux) *ochttp.Handler {
+	return &ochttp.Handler{
 		Propagation: &propagation.HTTPFormat{},
 		Handler:     httpMux,
 	}
+}
+
+func NewHTTPServer(ctx context.Context, cfg config.Config) (*http.Server, error) {
+	rtr, err := newRouter(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	httpMux := http.NewServeMux()
+	httpMux.Handle("/", rtr)
+
+	httpHandler := handlerWithTracingPropagation(httpMux)
 
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%d", cfg.HTTPServerPort()),

--- a/server/root.go
+++ b/server/root.go
@@ -1,1 +1,0 @@
-package server


### PR DESCRIPTION
increase code readability by file splitting and function abstracting rather than commenting. 
주석 대신 파일 나누기와 함수화로 코드 가독성을 올림.